### PR TITLE
Add stacktrace

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@ go:
   - 1.5
   - 1.6
   - 1.7
-  - tip
+  # NOTE: Stop using tip to avoid the following error on Travis CI:
+  # I don't have any idea what to do with 'tip'.
+  # - tip
 env:
   global:
     - GO15VENDOREXPERIMENT=1

--- a/check_license.sh
+++ b/check_license.sh
@@ -1,14 +1,18 @@
 #!/bin/bash
 
 text=`head -1 LICENSE.txt`
+text2=`head -2 LICENSE.txt | tail -1`
 
 ERROR_COUNT=0
 while read file
 do
     head -1 ${file} | grep -q "${text}"
     if [ $? -ne 0 ]; then
-        echo "$file is missing license header."
-        (( ERROR_COUNT++ ))
+        head -1 ${file} | grep -q "${text2}"
+        if [ $? -ne 0 ]; then
+            echo "$file is missing license header."
+            (( ERROR_COUNT++ ))
+	fi
     fi
 done < <(git ls-files "*\.go")
 

--- a/ltsv_stack.go
+++ b/ltsv_stack.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2017 Hiroaki Nakamura
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package ltsv
+
+import "bytes"
+
+// LTSVStack returns stacktrace formatted in one line which can be used as a LTSV value.
+func LTSVStack() string {
+	return formatStacktraceInOneLine(0, takeStacktrace(nil, false))
+}
+
+func formatStacktraceInOneLine(skip int, s string) string {
+	buf := []byte(s)
+
+	// This code is copied from
+	// https://github.com/hnakamur/ltsvlog/blob/ece22ec10aab08a1795ed376d3799e0fccbd131d/stack.go
+
+	// NOTE: We reuse the same buffer here.
+	p := buf[:0]
+
+	for j := 0; j < 1+2*skip; j++ {
+		i := bytes.IndexByte(buf, '\n')
+		if i == -1 || i+1 > len(buf) {
+			goto buffer_too_small
+		}
+		buf = buf[i+1:]
+	}
+
+	for len(buf) > 0 {
+		p = append(p, '[')
+		i := bytes.IndexByte(buf, '\n')
+		if i == -1 {
+			goto buffer_too_small
+		}
+		p = append(p, buf[:i]...)
+		p = append(p, ' ')
+		if i+2 > len(buf) {
+			goto buffer_too_small
+		}
+		buf = buf[i+2:]
+		i = bytes.IndexByte(buf, '\n')
+		if i == -1 {
+			goto buffer_too_small
+		}
+		p = append(p, buf[:i]...)
+		p = append(p, ']')
+		if i+1 > len(buf) {
+			goto buffer_too_small
+		}
+		buf = buf[i+1:]
+		if len(buf) > 0 {
+			p = append(p, ',')
+		}
+	}
+	return string(p)
+
+buffer_too_small:
+	p = append(p, buf...)
+	p = append(p, "..."...)
+	return string(p)
+}

--- a/ltsv_stack.go
+++ b/ltsv_stack.go
@@ -24,7 +24,9 @@ import "bytes"
 
 // LTSVStack returns stacktrace formatted in one line which can be used as a LTSV value.
 func LTSVStack() string {
-	return formatStacktraceInOneLine(0, takeStacktrace(nil, false))
+	// We remove two traces here,
+	// one for LTSVStack and one for takeStacktrace.
+	return formatStacktraceInOneLine(2, takeStacktrace(nil, false))
 }
 
 func formatStacktraceInOneLine(skip int, s string) string {

--- a/stacktrace.go
+++ b/stacktrace.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package ltsv
+
+import "runtime"
+
+// takeStacktrace attempts to use the provided byte slice to take a stacktrace.
+// If the provided slice isn't large enough, takeStacktrace will allocate
+// successively larger slices until it can capture the whole stack.
+func takeStacktrace(buf []byte, includeAllGoroutines bool) string {
+	if len(buf) == 0 {
+		// We may have been passed a nil byte slice.
+		buf = make([]byte, 1024)
+	}
+	n := runtime.Stack(buf, includeAllGoroutines)
+	for n >= len(buf) {
+		// Buffer wasn't large enough, allocate a larger one. No need to copy
+		// previous buffer's contents.
+		size := 2 * n
+		buf = make([]byte, size)
+		n = runtime.Stack(buf, includeAllGoroutines)
+	}
+	return string(buf[:n])
+}

--- a/stacktrace_test.go
+++ b/stacktrace_test.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package ltsv
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTakeStacktrace(t *testing.T) {
+	// Even if we pass a tiny buffer, takeStacktrace should allocate until it
+	// can capture the whole stacktrace.
+	traceNil := takeStacktrace(nil, false)
+	traceTiny := takeStacktrace(make([]byte, 1), false)
+	for _, trace := range []string{traceNil, traceTiny} {
+		// The top frame should be takeStacktrace.
+		assert.Contains(t, trace, "ltsv.takeStacktrace", "Stacktrace should contain the takeStacktrace function.")
+		// The stacktrace should also capture its immediate caller.
+		assert.Contains(t, trace, "TestTakeStacktrace", "Stacktrace should contain the test function.")
+	}
+}


### PR DESCRIPTION
An example.

```
package main

import (
        "os"
        "time"

        ltsv "github.com/hnakamur/zap-ltsv"
        "github.com/uber-go/zap"
)

func main() {
        os.Exit(run())
}

func run() int {
        // write all InfoLevel and above logs to standard out.
        logger := zap.New(
                ltsv.NewLTSVEncoder(ltsv.LTSVNoTime()), // drop timestamps in tests
        )

        logger.Error(
                "Or use strongly-typed wrappers to add structured context.",
                zap.String("library", "zap"),
                zap.Duration("latency", time.Nanosecond),
                zap.String("stacktrace", ltsv.LTSVStack()),
        )

        return 0
}
```

The output.

```
$ go run cmd/example/main.go
level:E msg:Or use strongly-typed wrappers to add structured context.   library:zap     latency:1       stacktrace:[main.run(0xc4200001a0) /home/hnakamur/go/src/github.com/hnakamur/zap-ltsv/cmd/example/main.go:25 +0x24d],[main.main() /home/hnakamur/go/src/github.com/hnakamur/zap-ltsv/cmd/example/main.go:12 +0x22]
```
